### PR TITLE
Feature/issue#19/introduction of  geolocation api

### DIFF
--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -34,6 +34,7 @@ export const SearchForm: React.FC<SearchFormProps> = ({
 
     setSearchKeyword(seachWordValue);
 
+    //APIへのルーティングパス
     const mutationData = await fetcher(`api/groumet/${seachWordValue}`);
 
     mutate(mutationData).catch((error) => {

--- a/src/types/geolocation.ts
+++ b/src/types/geolocation.ts
@@ -1,0 +1,22 @@
+export interface Position {
+  coords: Coordinates;
+  timestamp: number;
+}
+
+export interface Coordinates {
+  accuracy: number;
+  altitude: number | null;
+  altitudeAccuracy: number | null;
+  heading: number | null;
+  latitude: number;
+  longitude: number;
+  speed: number | null;
+}
+
+export interface PositionError {
+  PERMISSION_DENIED: number;
+  POSITION_UNAVAILABLE: number;
+  TIMEOUT: number;
+  code: number;
+  message: string;
+}

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -2,7 +2,6 @@ import { PositionError, Position } from '@/types/geolocation';
 import { resolve } from 'path';
 import { env } from 'process';
 import { useEffect, useState, useRef } from 'react';
-import { fetcher } from './fetcher';
 
 // geolocation APIをラップ化してfetcherとしてuseSWRで呼び出す
 export const fetcher = () => {

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -4,7 +4,7 @@ import { env } from 'process';
 import { useEffect, useState, useRef } from 'react';
 import { fetcher } from './fetcher';
 
-export const currentFetcher = () => {
+// geolocation APIをラップ化してfetcherとしてuseSWRで呼び出す
   return new Promise(
     (res: (value?: Position) => void, rej: (reson?: PositionError) => void) => {
       navigator.geolocation.getCurrentPosition(res, rej);

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -5,3 +5,20 @@ export const currentFetcher = () => {
     },
   );
 };
+
+export const geoFetcher = () => {
+  return new Promise((res, rej) => {
+    const onSuccess = async (position: any) => {
+      const latitude = String(position?.coords?.latitude);
+      const longitude = String(position?.coords?.longitude);
+      const result = await fetch(
+        `${env.API_URL_ROOT}&lat=${encodeURI(latitude)}&lng=${encodeURI(
+          longitude,
+        )}`,
+      );
+      const data = await result.json();
+      resolve(data);
+    };
+    navigator.geolocation.getCurrentPosition(onSuccess, rej);
+  });
+};

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -12,6 +12,7 @@ export const currentFetcher = () => {
   );
 };
 
+// TODO: 現在地取得に加えて範囲を指定したい
 export const geoFetcher = () => {
   return new Promise((res, rej) => {
     const onSuccess = async (position: any) => {

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -5,6 +5,7 @@ import { useEffect, useState, useRef } from 'react';
 import { fetcher } from './fetcher';
 
 // geolocation APIをラップ化してfetcherとしてuseSWRで呼び出す
+export const fetcher = () => {
   return new Promise(
     (res: (value?: Position) => void, rej: (reson?: PositionError) => void) => {
       navigator.geolocation.getCurrentPosition(res, rej);

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -1,0 +1,7 @@
+export const currentFetcher = () => {
+  return new Promise(
+    (res: (value?: Position) => void, rej: (reson?: PositionError) => void) => {
+      navigator.geolocation.getCurrentPosition(res, rej);
+    },
+  );
+};

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -1,3 +1,9 @@
+import { PositionError, Position } from '@/types/geolocation';
+import { resolve } from 'path';
+import { env } from 'process';
+import { useEffect, useState, useRef } from 'react';
+import { fetcher } from './fetcher';
+
 export const currentFetcher = () => {
   return new Promise(
     (res: (value?: Position) => void, rej: (reson?: PositionError) => void) => {


### PR DESCRIPTION
## 概要
geolocationAPI を導入し、緯度と軽度を取得できるようにしました
geolocationはそのままでは使えず、useEffectかpromisekでラップする必要性あり
windowコマンドがそのままだと使えない
<!-- なにをやったかを書く -->

## Issue

<!--Issueがある場合はリンクを張る -->

- issue: #19 
- close: #19 

## 変更内容

<!-- 変更内容を比較しやすいよう、変更前（AS-IS）と変更後（TO-BE）でわかりやすく簡潔に書く -->

### AS-IS

### TO-BE
* geolocation APIを導入
## スクリーンショット

| AS-IS | TO-BE |
| :---: | :---: |
| image | image |

## リファレンス
* ラップ化の[記事](https://qiita.com/makotoyc/items/aee473b341cd3a7bd31f)
* [navigatorをSSRで使うときの対処方法](https://qiita.com/akki-memo/items/bd14d9af5dc1be8e04c9)
<!-- 参考になるリンク等あれば貼る -->
