### PR TITLE
issue#22: 店舗検索出力画面の実装

### DIFF
--- a/src/pages/api/shop/index.ts
+++ b/src/pages/api/shop/index.ts
@@ -1,0 +1,31 @@
+import fetcher from '@/utils/fetcher';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  const {
+    query: { shopId },
+  } = req;
+
+  if (typeof process.env.API_URL_ROOT === 'undefined' || shopId === undefined) {
+    return;
+  }
+
+  const API_URL_ROOT = process.env.NEXT_PUBLIC_API_URL_ROOT;
+
+  const shopIdString: string = Array.isArray(shopId)
+    ? shopId.join(' ')
+    : shopId;
+
+  const API_URL =
+    typeof shopId === 'undefined' || shopId == null
+      ? API_URL_ROOT
+      : `${API_URL_ROOT}&id=${encodeURI(shopIdString)}`;
+  console.log(API_URL);
+  const data = await fetcher(API_URL);
+  console.log(data);
+  res.end(JSON.stringify(data));
+};
+export default handler;

--- a/src/pages/api/shop/index.ts
+++ b/src/pages/api/shop/index.ts
@@ -23,9 +23,7 @@ const handler = async (
     typeof shopId === 'undefined' || shopId == null
       ? API_URL_ROOT
       : `${API_URL_ROOT}&id=${encodeURI(shopIdString)}`;
-  console.log(API_URL);
   const data = await fetcher(API_URL);
-  console.log(data);
   res.end(JSON.stringify(data));
 };
 export default handler;

--- a/src/pages/api/shop/index.ts
+++ b/src/pages/api/shop/index.ts
@@ -23,6 +23,7 @@ const handler = async (
     typeof shopId === 'undefined' || shopId == null
       ? API_URL_ROOT
       : `${API_URL_ROOT}&id=${encodeURI(shopIdString)}`;
+
   const data = await fetcher(API_URL);
   res.end(JSON.stringify(data));
 };

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -1,9 +1,11 @@
+import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { useEffect } from 'react';
 import fetcher from '@/utils/fetcher';
 import { Shop, ShopDetail } from '@/types/shop';
 import styled from 'styled-components';
 
+const Sample: React.FC = () => {
   const router = useRouter();
   const shopId = String(router.query.shopId);
   const [shops, setShops] = useState<Shop[]>([]);

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -17,3 +17,9 @@ import styled from 'styled-components';
     fetchShops();
   }, [shopId]);
 
+  return (
+    <>
+      <div>sample</div>
+    </>
+  );
+};

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -1,0 +1,5 @@
+import React, { useState } from 'react';
+import { useEffect } from 'react';
+import fetcher from '@/utils/fetcher';
+import { Shop, ShopDetail } from '@/types/shop';
+import styled from 'styled-components';

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -23,3 +23,9 @@ import styled from 'styled-components';
     </>
   );
 };
+
+export default Sample;
+
+const Container = styled.div``;
+
+const Image = styled.img``;

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -3,3 +3,17 @@ import { useEffect } from 'react';
 import fetcher from '@/utils/fetcher';
 import { Shop, ShopDetail } from '@/types/shop';
 import styled from 'styled-components';
+
+  const router = useRouter();
+  const shopId = String(router.query.shopId);
+  const [shops, setShops] = useState<Shop[]>([]);
+  useEffect(() => {
+    const fetchShops = async () => {
+      const response = await fetcher(
+        `http://localhost:3000/api/shop/?shopId=${encodeURI(shopId)}`,
+      );
+      setShops(response.results.shop);
+    };
+    fetchShops();
+  }, [shopId]);
+

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -35,6 +35,7 @@ const ShopListPage: React.FC = () => {
     fetchShops();
   }, [lat, lng, range]);
 
+  //TODO cssのスタイルとUIの設計を行う
   return (
     <>
       <Container>

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -32,7 +32,7 @@ const ShopListPage: React.FC = () => {
       console.log(response.results.shop);
       setShops(response.results.shop);
     };
-    fetchUsers();
+    fetchShops();
   }, [lat, lng, range]);
 
   return (

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -8,6 +8,7 @@ import useSWR from 'swr';
 import { locationFetcher } from '@/utils/geolocation';
 import { ConstructionOutlined } from '@mui/icons-material';
 import { Shop, ShopListResponseType } from '@/types/shop';
+import styled from 'styled-components';
 
 const ShopListPage: React.FC = () => {
   const router = useRouter();
@@ -23,13 +24,12 @@ const ShopListPage: React.FC = () => {
   const range = String(router.query.ran);
 
   useEffect(() => {
-    const fetchUsers = async () => {
+    const fetchShops = async () => {
       const response = await fetcher(
         `http://localhost:3000/api/search?lat=${encodeURI(
           lat,
         )}3&lng=${encodeURI(lng)}&ran=${encodeURI(range)}`,
       );
-      console.log(response.results.shop);
       setShops(response.results.shop);
     };
     fetchShops();

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -37,7 +37,25 @@ const ShopListPage: React.FC = () => {
 
   return (
     <>
-      <div>Hello </div>
+      <Container>
+        <div>
+          {shops ? (
+            shops.map((shop: Shop) => {
+              return (
+                <div key={shop.id}>
+                  <h1>{shop.name}</h1>
+                  <Image src={shop.photo.pc.l} alt={shop.name} />
+                  <p>
+                    <span>アクセス方法:{shop.access}</span>
+                  </p>
+                </div>
+              );
+            })
+          ) : (
+            <div>Loading ...</div>
+          )}
+        </div>
+      </Container>
     </>
   );
 };

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -61,3 +61,7 @@ const ShopListPage: React.FC = () => {
 };
 
 export default ShopListPage;
+
+const Container = styled.div``;
+
+const Image = styled.img``;

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -9,6 +9,7 @@ import { locationFetcher } from '@/utils/geolocation';
 import { ConstructionOutlined } from '@mui/icons-material';
 import { Shop, ShopListResponseType } from '@/types/shop';
 import styled from 'styled-components';
+import Link from 'next/link';
 
 const ShopListPage: React.FC = () => {
   const router = useRouter();
@@ -43,13 +44,22 @@ const ShopListPage: React.FC = () => {
           {shops ? (
             shops.map((shop: Shop) => {
               return (
-                <div key={shop.id}>
-                  <h1>{shop.name}</h1>
-                  <Image src={shop.photo.pc.l} alt={shop.name} />
-                  <p>
-                    <span>アクセス方法:{shop.access}</span>
-                  </p>
-                </div>
+                <Link
+                  key={shop.id}
+                  href={{
+                    pathname: '/shops/[shopId]',
+                    query: { shopId: shop.id },
+                  }}
+                >
+                  <div>
+                    <h1>{shop.name}</h1>
+                    <h2>{shop.id}</h2>
+                    <Image src={shop.photo.pc.l} alt={shop.name} />
+                    <p>
+                      <span>アクセス方法:{shop.access}</span>
+                    </p>
+                  </div>
+                </Link>
               );
             })
           ) : (

--- a/src/types/shop.d.ts
+++ b/src/types/shop.d.ts
@@ -5,7 +5,9 @@ interface Shop {
   id: string;
   name: string;
   access: string;
-  thumbnail: string;
+  photo: {
+    pc: Photo_PC;
+  };
 }
 
 // 店舗詳細オブジェクト
@@ -14,6 +16,13 @@ interface ShopDetail {
   address: string;
   Hours: Date;
   Image: string;
+}
+
+// サムネイル画像のPC版オブジェクト
+interface Photo_PC {
+  l: string;
+  m: string;
+  s: string;
 }
 
 //店舗一覧表示オブジェクト


### PR DESCRIPTION
## 概要
<!-- なにをやったかを書く -->
検索した範囲から店舗をリストで出力する画面の実装です。
下記に取得した店舗の情報をまとめてます
* 店舗名
* アクセス
* サムネイル画像

現状はスタイルやUIのデザインを加えていないので、画面に情報が表示されるだけです
実装にはuseEffectでグルメサーチAPIを呼び出して取得しています
## Issue

<!--Issueがある場合はリンクを張る -->

- issue: #22 
- close: #22 

## 変更内容

<!-- 変更内容を比較しやすいよう、変更前（AS-IS）と変更後（TO-BE）でわかりやすく簡潔に書く -->

### AS-IS

### TO-BE
検索出力画面を実装しました


## スクリーンショット
![スクリーンショット 0004-11-16 14 50 47](https://user-images.githubusercontent.com/82755414/202095129-11b4b845-d0d5-4502-beb4-9d21018e168d.png)


## リファレンス
こちらの[記事](https://qiita.com/dtakkiy/items/490a2a2ead301474edc6)を参考に実装してます
<!-- 参考になるリンク等あれば貼る -->
