### PR TITLE
issue#28: 詳細ページにリンクで移動する導線を実装

### DIFF
--- a/src/pages/api/shop/index.ts
+++ b/src/pages/api/shop/index.ts
@@ -1,0 +1,31 @@
+import fetcher from '@/utils/fetcher';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  const {
+    query: { shopId },
+  } = req;
+
+  if (typeof process.env.API_URL_ROOT === 'undefined' || shopId === undefined) {
+    return;
+  }
+
+  const API_URL_ROOT = process.env.NEXT_PUBLIC_API_URL_ROOT;
+
+  const shopIdString: string = Array.isArray(shopId)
+    ? shopId.join(' ')
+    : shopId;
+
+  const API_URL =
+    typeof shopId === 'undefined' || shopId == null
+      ? API_URL_ROOT
+      : `${API_URL_ROOT}&id=${encodeURI(shopIdString)}`;
+  console.log(API_URL);
+  const data = await fetcher(API_URL);
+  console.log(data);
+  res.end(JSON.stringify(data));
+};
+export default handler;

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -1,9 +1,11 @@
+import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { useEffect } from 'react';
 import fetcher from '@/utils/fetcher';
 import { Shop, ShopDetail } from '@/types/shop';
 import styled from 'styled-components';
 
+const Sample: React.FC = () => {
   const router = useRouter();
   const shopId = String(router.query.shopId);
   const [shops, setShops] = useState<Shop[]>([]);

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -17,3 +17,9 @@ import styled from 'styled-components';
     fetchShops();
   }, [shopId]);
 
+  return (
+    <>
+      <div>sample</div>
+    </>
+  );
+};

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -1,0 +1,5 @@
+import React, { useState } from 'react';
+import { useEffect } from 'react';
+import fetcher from '@/utils/fetcher';
+import { Shop, ShopDetail } from '@/types/shop';
+import styled from 'styled-components';

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -23,3 +23,9 @@ import styled from 'styled-components';
     </>
   );
 };
+
+export default Sample;
+
+const Container = styled.div``;
+
+const Image = styled.img``;

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -3,3 +3,17 @@ import { useEffect } from 'react';
 import fetcher from '@/utils/fetcher';
 import { Shop, ShopDetail } from '@/types/shop';
 import styled from 'styled-components';
+
+  const router = useRouter();
+  const shopId = String(router.query.shopId);
+  const [shops, setShops] = useState<Shop[]>([]);
+  useEffect(() => {
+    const fetchShops = async () => {
+      const response = await fetcher(
+        `http://localhost:3000/api/shop/?shopId=${encodeURI(shopId)}`,
+      );
+      setShops(response.results.shop);
+    };
+    fetchShops();
+  }, [shopId]);
+

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -9,6 +9,7 @@ import { locationFetcher } from '@/utils/geolocation';
 import { ConstructionOutlined } from '@mui/icons-material';
 import { Shop, ShopListResponseType } from '@/types/shop';
 import styled from 'styled-components';
+import Link from 'next/link';
 
 const ShopListPage: React.FC = () => {
   const router = useRouter();
@@ -43,13 +44,22 @@ const ShopListPage: React.FC = () => {
           {shops ? (
             shops.map((shop: Shop) => {
               return (
-                <div key={shop.id}>
-                  <h1>{shop.name}</h1>
-                  <Image src={shop.photo.pc.l} alt={shop.name} />
-                  <p>
-                    <span>アクセス方法:{shop.access}</span>
-                  </p>
-                </div>
+                <Link
+                  key={shop.id}
+                  href={{
+                    pathname: '/shops/[shopId]',
+                    query: { shopId: shop.id },
+                  }}
+                >
+                  <div>
+                    <h1>{shop.name}</h1>
+                    <h2>{shop.id}</h2>
+                    <Image src={shop.photo.pc.l} alt={shop.name} />
+                    <p>
+                      <span>アクセス方法:{shop.access}</span>
+                    </p>
+                  </div>
+                </Link>
               );
             })
           ) : (


### PR DESCRIPTION
## 概要
<!-- なにをやったかを書く -->
詳細ページにリンクを導入し、詳細ページに飛べるようにしています
idを取得し、shops/[shopId]のページに飛ぶようにしています
`shops/[shopId]`を呼び出した際に、バックエンド側で`api/shop`を呼び出すようにしています
`api/shop`ではidをクエリとして渡し、グルメサーチAPIのクエリパラメーターに変換しています


## Issue

<!--Issueがある場合はリンクを張る -->

- issue: #28 
- close: #28 

## 変更内容

<!-- 変更内容を比較しやすいよう、変更前（AS-IS）と変更後（TO-BE）でわかりやすく簡潔に書く -->

### AS-IS

### TO-BE
* Linkタグを追加
* Linkタグから詳細画面の導線を追加しました


## スクリーンショット

| AS-IS | TO-BE |
| :---: | :---: |
| image | image |

## リファレンス


<!-- 参考になるリンク等あれば貼る -->
[next/Link](https://qiita.com/mt_816/items/d4e685953afa4906dd38)を使ったリンクタグの実装
useRouter + Linkタグの実装についての[記事
](https://qiita.com/IYA_UFO/items/f13577bad7dd9ef1ae89)
