### PR TITLE
issue#36: 店舗詳細ページの実装

### DIFF
--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -11,7 +11,6 @@ const Sample: React.FC = () => {
   // TODO: クエリを読み込むため、再レンダリングをするとshopIdが消えてしまう
   const shopId = String(router.query.shopId);
   const [shops, setShops] = useState<Shop[]>([]);
-  console.log(shopId);
   useEffect(() => {
     const fetchShops = async () => {
       const response = await fetcher(

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { useEffect } from 'react';
 import fetcher from '@/utils/fetcher';
-import { Shop, ShopDetail } from '@/types/shop';
+import { Shop } from '@/types/shop';
 import styled from 'styled-components';
 
 const Sample: React.FC = () => {

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -21,7 +21,28 @@ const Sample: React.FC = () => {
 
   return (
     <>
-      <div>sample</div>
+      <Container>
+        <div>
+          {shops ? (
+            shops.map((shop: Shop) => {
+              return (
+                <div key={shop.id}>
+                  <h1>{shop.name}</h1>
+                  <Image src={shop.photo.pc.m} alt={shop.name} />
+                  <p>
+                    <span>住所:{shop.address}</span>
+                  </p>
+                  <div>
+                    <p>営業時間:{shop.open}</p>
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <div>Loading ...</div>
+          )}
+        </div>
+      </Container>
     </>
   );
 };

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -7,8 +7,11 @@ import styled from 'styled-components';
 
 const Sample: React.FC = () => {
   const router = useRouter();
+
+  // TODO: クエリを読み込むため、再レンダリングをするとshopIdが消えてしまう
   const shopId = String(router.query.shopId);
   const [shops, setShops] = useState<Shop[]>([]);
+  console.log(shopId);
   useEffect(() => {
     const fetchShops = async () => {
       const response = await fetcher(

--- a/src/types/shop.d.ts
+++ b/src/types/shop.d.ts
@@ -8,7 +8,7 @@ interface Shop {
   photo: {
     pc: Photo_PC;
   };
-  adress: string;
+  address: string;
   open: string;
 }
 

--- a/src/types/shop.d.ts
+++ b/src/types/shop.d.ts
@@ -8,14 +8,8 @@ interface Shop {
   photo: {
     pc: Photo_PC;
   };
-}
-
-// 店舗詳細オブジェクト
-interface ShopDetail {
-  text: string;
-  address: string;
-  Hours: Date;
-  Image: string;
+  adress: string;
+  open: string;
 }
 
 // サムネイル画像のPC版オブジェクト

--- a/src/types/shop.d.ts
+++ b/src/types/shop.d.ts
@@ -19,6 +19,11 @@ interface Photo_PC {
   s: string;
 }
 
+interface Photo_Moblile {
+  l: string;
+  s: string;
+}
+
 //店舗一覧表示オブジェクト
 export interface ShopListResponseType {
   results: {


### PR DESCRIPTION
## 概要
店舗詳細ページの画面を実装しました
以下に店舗詳細に必要な情報をまとめています
* 店舗名称
* 住所
* 営業時間
* 画像

現状だと詳細ページで再レンダリングすると取得できなくなってしまうため、改善する必要がある
useEffectでバックエンドを呼び出すときにクエリがとれていない原因が考えられるため、再レンダリングしたときの実装ページを変更したい
<!-- なにをやったかを書く -->

## Issue

<!--Issueがある場合はリンクを張る -->

- issue: #36 
- close: #36 

## 変更内容

<!-- 変更内容を比較しやすいよう、変更前（AS-IS）と変更後（TO-BE）でわかりやすく簡潔に書く -->

### AS-IS

### TO-BE
店舗詳細画面の実装を行いました


## スクリーンショット

![スクリーンショット 0004-11-16 21 45 36](https://user-images.githubusercontent.com/82755414/202186018-6fab9934-428c-4a3c-a401-390fe5a69e81.png)

## リファレンス

<!-- 参考になるリンク等あれば貼る -->
