### PR TITLE
issue#38: 店舗詳細ページのUIデザインの実装

### DIFF
--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -28,16 +28,12 @@ const Sample: React.FC = () => {
           {shops ? (
             shops.map((shop: Shop) => {
               return (
-                <div key={shop.id}>
-                  <h1>{shop.name}</h1>
-                  <Image src={shop.photo.pc.m} alt={shop.name} />
-                  <p>
-                    <span>住所:{shop.address}</span>
-                  </p>
-                  <div>
-                    <p>営業時間:{shop.open}</p>
-                  </div>
-                </div>
+              <ShopContent key={shop.id}>
+                <ShopInfoContent key={shop.id}>
+                </ShopInfoContent>
+                <ShopAirticleContent key={shop.id}>
+                </ShopAirticleContent>
+              </ShopContent>
               );
             })
           ) : (

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -48,6 +48,10 @@ const Sample: React.FC = () => {
                   </ShopDetail>
                 </ShopInfoContent>
                 <ShopAirticleContent key={shop.id}>
+                  <Image
+                    src={`${shop.photo.pc.l}`}
+                    alt="画像がありません"
+                  ></Image>
                 </ShopAirticleContent>
               </ShopContent>
               );

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -30,6 +30,10 @@ const Sample: React.FC = () => {
               return (
               <ShopContent key={shop.id}>
                 <ShopInfoContent key={shop.id}>
+                  <ShopInfo>
+                  </ShopInfo>
+                  <ShopDetail>
+                  </ShopDetail>
                 </ShopInfoContent>
                 <ShopAirticleContent key={shop.id}>
                 </ShopAirticleContent>

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -24,10 +24,9 @@ const Sample: React.FC = () => {
   return (
     <>
       <Container>
-        <div>
-          {shops ? (
-            shops.map((shop: Shop) => {
-              return (
+        {shops ? (
+          shops.map((shop: Shop) => {
+            return (
               <ShopContent key={shop.id}>
                 <ShopInfoContent key={shop.id}>
                   <ShopInfo>
@@ -55,12 +54,11 @@ const Sample: React.FC = () => {
                   <ShopCatch>{shop.catch}</ShopCatch>
                 </ShopAirticleContent>
               </ShopContent>
-              );
-            })
-          ) : (
-            <div>Loading ...</div>
-          )}
-        </div>
+            );
+          })
+        ) : (
+          <div>Loading ...</div>
+        )}
       </Container>
     </>
   );
@@ -70,4 +68,60 @@ export default Sample;
 
 const Container = styled.div``;
 
-const Image = styled.img``;
+const ShopContent = styled.div`
+  width: 70%;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+
+  margin: 3rem auto;
+  padding: 40px;
+
+  background-color: #fff;
+`;
+
+const ShopInfoContent = styled.div``;
+
+const ShopInfo = styled.div`
+  border-bottom: 0.2px solid #595960;
+`;
+
+const ShopSection = styled.div`
+  display: flex;
+`;
+
+const ShopName = styled.div`
+  width: 90%;
+
+  font-size: 2.4rem;
+  font-weight: bold;
+  color: #ffaf69;
+`;
+
+const ShopOfficalInfo = styled.div`
+  padding: 10px;
+`;
+
+const ShopItem = styled.p`
+  padding-right: 20px;
+
+  font-weight: bold;
+  font-size: 12px;
+  color: #595960;
+`;
+
+const ShopDetail = styled.div``;
+
+const ShopAirticleContent = styled.div`
+  padding-top: 40px;
+  border-top: 0.2px solid #595960;
+`;
+
+const Image = styled.img`
+  width: 60%;
+`;
+
+const ShopCatch = styled.h2`
+  /* margin: auto 40px; */
+
+  text-align: center;
+  color: #13131e;
+`;

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -52,6 +52,7 @@ const Sample: React.FC = () => {
                     src={`${shop.photo.pc.l}`}
                     alt="画像がありません"
                   ></Image>
+                  <ShopCatch>{shop.catch}</ShopCatch>
                 </ShopAirticleContent>
               </ShopContent>
               );

--- a/src/pages/shops/[shopId].tsx/index.tsx
+++ b/src/pages/shops/[shopId].tsx/index.tsx
@@ -31,8 +31,20 @@ const Sample: React.FC = () => {
               <ShopContent key={shop.id}>
                 <ShopInfoContent key={shop.id}>
                   <ShopInfo>
+                    <ShopName>{shop.name}</ShopName>
+                    <ShopSection>
+                      <ShopItem>最寄り駅:{shop.station_name}駅</ShopItem>
+                      <ShopItem>ジャンル:{shop.genre.name}</ShopItem>
+                    </ShopSection>
                   </ShopInfo>
                   <ShopDetail>
+                    <ShopOfficalInfo>
+                      <ShopItem>
+                        {shop.open} / {shop.close}
+                      </ShopItem>
+                      <ShopItem>予算:{shop.budget.name}</ShopItem>
+                      <ShopItem>住所:{shop.address}</ShopItem>
+                    </ShopOfficalInfo>
                   </ShopDetail>
                 </ShopInfoContent>
                 <ShopAirticleContent key={shop.id}>

--- a/src/types/shop.d.ts
+++ b/src/types/shop.d.ts
@@ -13,6 +13,8 @@ interface Shop {
   station_name: string;
   genre: Genre;
   close: string;
+  catch: string;
+  budget: Buget;
 }
 
 // サムネイル画像のPC版オブジェクト
@@ -29,6 +31,11 @@ interface Photo_Moblile {
 
 interface Genre {
   name: string;
+}
+
+interface Buget {
+  name: string;
+  average: string;
 }
 
 //店舗一覧表示オブジェクト


### PR DESCRIPTION
## 概要
店舗詳細ページのUIデザインを実装しました。
店舗詳細には以下の要素を入れています。
* 店舗名称
* 住所
* 営業時間
* 最寄駅
* ジャンル
* 予算
* 画像
* キャッチ

画像の右サイドが空白が多いため、変更したい

<!-- なにをやったかを書く -->

## Issue

<!--Issueがある場合はリンクを張る -->

- issue: #38 
- close: #38 

## 変更内容

<!-- 変更内容を比較しやすいよう、変更前（AS-IS）と変更後（TO-BE）でわかりやすく簡潔に書く -->

### AS-IS

### TO-BE
店舗詳細ページのUIデザインを実装

## スクリーンショット
<img width="1162" alt="スクリーンショット 0004-11-18 2 04 06" src="https://user-images.githubusercontent.com/82755414/202511012-d38e3399-05f1-492d-aaa4-3b2ae5fadd4f.png">


## リファレンス

<!-- 参考になるリンク等あれば貼る -->
