### PR TITLE
issue#52: 検索結果画面が表示されないバグの修正

### DIFF
--- a/src/components/GeolocationSearchFrom.tsx
+++ b/src/components/GeolocationSearchFrom.tsx
@@ -1,12 +1,7 @@
-import { locationFetcher } from '@/utils/geolocation';
 import React, { useState } from 'react';
-import useSWR from 'swr';
 import styled from 'styled-components';
-import { Controller, SubmitHandler, useForm } from 'react-hook-form';
-import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
-import { Navigate, useNavigate } from 'react-router-dom';
-import Router, { useRouter } from 'next/router';
-import fetcher from '@/utils/fetcher';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/router';
 import ReactSelect from 'react-select';
 import { CiForkAndKnife } from 'react-icons/ci';
 

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,8 +1,4 @@
-import { ConstructionOutlined } from '@mui/icons-material';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
-import { useState } from 'react';
-import { start } from 'repl';
 import styled from 'styled-components';
 
 interface props {

--- a/src/pages/api/search/index.tsx
+++ b/src/pages/api/search/index.tsx
@@ -1,7 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import fetcher from '@/utils/fetcher';
-import useSWR from 'swr';
-import { locationFetcher } from '@/utils/geolocation';
 
 const handler = async (
   req: NextApiRequest,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,3 @@
-import { SearchForm } from '@/components/SearchForm';
-import { useShopDataSWR } from '@/utils/hooks/useShopDataSWR';
-import { useUserInputKeywordState } from '@/utils/recoil/useUserInputKeywordState';
 import SearchPage from './search';
 
 interface Props {

--- a/src/pages/shops/[shop].tsx
+++ b/src/pages/shops/[shop].tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
-import { useEffect } from 'react';
+import React from 'react';
 import fetcher from '@/utils/fetcher';
 import { Shop } from '@/types/shop';
 import styled from 'styled-components';

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -31,9 +31,9 @@ const ShopListPage: React.FC = () => {
     const fetchShops = async () => {
       const response = await fetcher(
         `http://localhost:3000/api/search?lat=${encodeURI(lat)}&lng=${encodeURI(
-      lng,
-    )}&ran=${encodeURI(range)}&start=${encodeURI(start)}`,
-  );
+          lng,
+        )}&ran=${encodeURI(range)}&start=${encodeURI(start)}`,
+      );
       setShops(response.results.shop);
       console.log(response);
     };
@@ -45,9 +45,6 @@ const ShopListPage: React.FC = () => {
   return (
     <>
       <Container>
-        <ShopNumber>
-          {shops ? shops.results.results_available : <span>0</span>}件
-        </ShopNumber>
         {shops ? (
           shops.map((shop: Shop) => {
             return (
@@ -87,9 +84,6 @@ const ShopListPage: React.FC = () => {
         )}
         <Pagination
           currentPageNumber={currentPageNumber}
-          maxpageNumber={Math.ceil(
-            shops ? Number(shops.results.results_available) / 9 : 0,
-          )}
           range={range}
           startNumber={startNumber}
         ></Pagination>

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -48,7 +48,7 @@ const ShopListPage: React.FC = () => {
           {shops ? shops.results.results_available : <span>0</span>}件
         </ShopNumber>
         {shops ? (
-          shops.results.shop.map((shop: Shop) => {
+          shops.map((shop: Shop) => {
             return (
               <ShopSection key={shop.id}>
                 <Link

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -41,6 +41,7 @@ const ShopListPage: React.FC = () => {
   }, [lat, lng, range, start]);
 
   //TODO cssのスタイルとUIの設計を行う
+  //TODO ページングのMaxPageをしていないため、ページングの修正が必要
   return (
     <>
       <Container>

--- a/src/pages/shops/index.tsx
+++ b/src/pages/shops/index.tsx
@@ -25,12 +25,20 @@ const ShopListPage: React.FC = () => {
   const currentPageNumber =
     startNumber === 1 ? startNumber : (startNumber - 1) / 10 + 1;
 
-  const { data: shops } = useSWR(
-    `http://localhost:3000/api/search?lat=${encodeURI(lat)}3&lng=${encodeURI(
+  // shopsの配列に取得した店舗を入れていく
+  const [shops, setShops] = useState<Shop[]>();
+  useEffect(() => {
+    const fetchShops = async () => {
+      const response = await fetcher(
+        `http://localhost:3000/api/search?lat=${encodeURI(lat)}&lng=${encodeURI(
       lng,
     )}&ran=${encodeURI(range)}&start=${encodeURI(start)}`,
-    fetcher,
   );
+      setShops(response.results.shop);
+      console.log(response);
+    };
+    fetchShops();
+  }, [lat, lng, range, start]);
 
   //TODO cssのスタイルとUIの設計を行う
   return (

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -1,7 +1,4 @@
 import { PositionError, Position } from '@/types/geolocation';
-import { resolve } from 'path';
-import { env } from 'process';
-import { useEffect, useState, useRef } from 'react';
 
 // geolocation APIをラップ化してfetcherとしてuseSWRで呼び出す
 // TODO: APIディレクトリに入れたい


### PR DESCRIPTION
## 概要
検索画面表示時に、店舗を配列として検索結果を取得していたが、グルメサーチAPIのJSONのレスポンスとして返すとコンソール上で返ったきたJSONががundefinedになるバグを発見。
現段階では、Shopオブジェクトとして返すためにもとのコードに修正しました。
<!-- なにをやったかを書く -->

## Issue

<!--Issueがある場合はリンクを張る -->

- issue: #52 
- close: #52 

## 変更内容

<!-- 変更内容を比較しやすいよう、変更前（AS-IS）と変更後（TO-BE）でわかりやすく簡潔に書く -->

### AS-IS
検索画面が表示されない
### TO-BE
検索画面が表示される

## スクリーンショット

| AS-IS | TO-BE |
| :---: | :---: |
| image | image |

## リファレンス

<!-- 参考になるリンク等あれば貼る -->
